### PR TITLE
feat: added SMPP property 'systemType'

### DIFF
--- a/src/main/java/com/github/mikesafonov/smpp/config/SmppProperties.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmppProperties.java
@@ -67,14 +67,6 @@ public class SmppProperties {
          * Type of smpp connection
          */
         private ConnectionType connectionType = ConnectionType.TRANSMITTER_RECEIVER;
-
-        /**
-         * The systemType parameter is used to categorize the type of ESME that is binding to the SMSC.
-         * Examples include “VMS” (voice mail system) and “OTA” (over-the-air activation system).
-         * Specification of the systemType is optional - some SMSC’s may not require ESME’s to provide
-         * this detail. In this case, the ESME can set the systemType to NULL.
-         */
-        private String systemType;
     }
 
     @Data

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmppProperties.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmppProperties.java
@@ -67,6 +67,14 @@ public class SmppProperties {
          * Type of smpp connection
          */
         private ConnectionType connectionType = ConnectionType.TRANSMITTER_RECEIVER;
+
+        /**
+         * The systemType parameter is used to categorize the type of ESME that is binding to the SMSC.
+         * Examples include “VMS” (voice mail system) and “OTA” (over-the-air activation system).
+         * Specification of the systemType is optional - some SMSC’s may not require ESME’s to provide
+         * this detail. In this case, the ESME can set the systemType to NULL.
+         */
+        private String systemType;
     }
 
     @Data
@@ -142,5 +150,12 @@ public class SmppProperties {
          * Type of smpp connection
          */
         private ConnectionType connectionType;
+        /**
+         * The systemType parameter is used to categorize the type of ESME that is binding to the SMSC.
+         * Examples include “VMS” (voice mail system) and “OTA” (over-the-air activation system).
+         * Specification of the systemType is optional - some SMSC’s may not require ESME’s to provide
+         * this detail. In this case, the ESME can set the systevType to NULL.
+         */
+        private String systemType;
     }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/connection/ConnectionManagerFactory.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/connection/ConnectionManagerFactory.java
@@ -31,7 +31,7 @@ public class ConnectionManagerFactory {
         int maxTry = getOrDefault(smsc.getMaxTry(), defaults.getMaxTry());
 
         TransmitterConfiguration transmitterConfiguration = new TransmitterConfiguration(name,
-            smsc.getCredentials(), loggingBytes, loggingPdu, windowsSize);
+            smsc.getCredentials(), loggingBytes, loggingPdu, windowsSize, smsc.getSystemType());
 
         DefaultSmppClient client = new DefaultSmppClient();
         return new TransmitterConnectionManager(client, transmitterConfiguration, maxTry);
@@ -76,7 +76,7 @@ public class ConnectionManagerFactory {
 
 
         TransceiverConfiguration configuration = new TransceiverConfiguration(name, smsc.getCredentials(),
-            loggingBytes, loggingPdu, windowsSize);
+            loggingBytes, loggingPdu, windowsSize, smsc.getSystemType());
         DefaultSmppClient client = new DefaultSmppClient();
 
         return new TransceiverConnectionManager(client, configuration, smppSessionHandler, maxTry);

--- a/src/main/java/com/github/mikesafonov/smpp/core/connection/TransceiverConfiguration.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/connection/TransceiverConfiguration.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 
 public class TransceiverConfiguration extends BaseSmppSessionConfiguration {
     public TransceiverConfiguration(@NotNull String name, @NotNull SmppProperties.Credentials credentials,
-                                    boolean loggingBytes, boolean loggingPdu, int windowsSize) {
+                                    boolean loggingBytes, boolean loggingPdu, int windowsSize, String systemType) {
         super();
 
         setType(SmppBindType.TRANSCEIVER);
@@ -20,6 +20,7 @@ public class TransceiverConfiguration extends BaseSmppSessionConfiguration {
         setSystemId(credentials.getUsername());
         setPassword(credentials.getPassword());
         setWindowSize(windowsSize);
+        setSystemType(systemType);
 
         LoggingOptions loggingOptions = new LoggingOptions();
         loggingOptions.setLogBytes(loggingBytes);

--- a/src/main/java/com/github/mikesafonov/smpp/core/connection/TransmitterConfiguration.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/connection/TransmitterConfiguration.java
@@ -16,7 +16,7 @@ import static java.util.Objects.requireNonNull;
 public class TransmitterConfiguration extends BaseSmppSessionConfiguration {
 
     public TransmitterConfiguration(@NotNull String name, @NotNull SmppProperties.Credentials credentials,
-                                    boolean loggingBytes, boolean loggingPdu, int windowsSize) {
+                                    boolean loggingBytes, boolean loggingPdu, int windowsSize, String systemType) {
         super();
 
         setType(SmppBindType.TRANSMITTER);
@@ -26,6 +26,7 @@ public class TransmitterConfiguration extends BaseSmppSessionConfiguration {
         setSystemId(credentials.getUsername());
         setPassword(credentials.getPassword());
         setWindowSize(windowsSize);
+        setSystemType(systemType);
 
         LoggingOptions loggingOptions = new LoggingOptions();
         loggingOptions.setLogBytes(loggingBytes);

--- a/src/test/java/com/github/mikesafonov/smpp/core/connection/TransceiverConfigurationTest.java
+++ b/src/test/java/com/github/mikesafonov/smpp/core/connection/TransceiverConfigurationTest.java
@@ -13,9 +13,9 @@ class TransceiverConfigurationTest {
     @Test
     void shouldThrowNullPointerException() {
         assertThrows(NullPointerException.class, () -> new TransceiverConfiguration(null,
-                new SmppProperties.Credentials(), true, true, 1));
+                new SmppProperties.Credentials(), true, true, 1, null));
         assertThrows(NullPointerException.class, () -> new TransceiverConfiguration("asdasd",
-                null, true, true, 1));
+                null, true, true, 1, null));
     }
 
     @Test
@@ -26,7 +26,7 @@ class TransceiverConfigurationTest {
         boolean loggingPdu = Randomizer.randomBoolean();
         int windowsSize = Randomizer.randomInt();
         TransceiverConfiguration configuration =
-                new TransceiverConfiguration(name, credentials, loggingBytes, loggingPdu, windowsSize);
+                new TransceiverConfiguration(name, credentials, loggingBytes, loggingPdu, windowsSize, null);
 
         assertEquals(name, configuration.getName());
         assertEquals(credentials.getHost(), configuration.getHost());

--- a/src/test/java/com/github/mikesafonov/smpp/core/connection/TransmitterConfigurationTest.java
+++ b/src/test/java/com/github/mikesafonov/smpp/core/connection/TransmitterConfigurationTest.java
@@ -12,8 +12,8 @@ class TransmitterConfigurationTest {
 
     @Test
     void shouldThrowNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new TransmitterConfiguration(null, new SmppProperties.Credentials(), true, true, 1));
-        assertThrows(NullPointerException.class, () -> new TransmitterConfiguration("asdasd", null, true, true, 1));
+        assertThrows(NullPointerException.class, () -> new TransmitterConfiguration(null, new SmppProperties.Credentials(), true, true, 1, null));
+        assertThrows(NullPointerException.class, () -> new TransmitterConfiguration("asdasd", null, true, true, 1, null));
     }
 
     @Test
@@ -23,7 +23,7 @@ class TransmitterConfigurationTest {
         boolean loggingBytes = Randomizer.randomBoolean();
         boolean loggingPdu = Randomizer.randomBoolean();
         int windowsSize = Randomizer.randomInt();
-        TransmitterConfiguration transmitterConfiguration = new TransmitterConfiguration(name, credentials, loggingBytes, loggingPdu, windowsSize);
+        TransmitterConfiguration transmitterConfiguration = new TransmitterConfiguration(name, credentials, loggingBytes, loggingPdu, windowsSize, null);
 
         assertEquals(name, transmitterConfiguration.getName());
         assertEquals(credentials.getHost(), transmitterConfiguration.getHost());

--- a/src/test/java/com/github/mikesafonov/smpp/util/Randomizer.java
+++ b/src/test/java/com/github/mikesafonov/smpp/util/Randomizer.java
@@ -85,12 +85,14 @@ public class Randomizer {
 
     public static TransmitterConfiguration randomTransmitterConfiguration() {
         SmppProperties.Credentials credentials = randomCredentials();
-        return new TransmitterConfiguration(randomString(), credentials, randomBoolean(), randomBoolean(), randomInt());
+        return new TransmitterConfiguration(randomString(), credentials, randomBoolean(), randomBoolean(), randomInt(),
+            randomString());
     }
 
     public static TransceiverConfiguration randomTransceiverConfiguration() {
         SmppProperties.Credentials credentials = randomCredentials();
-        return new TransceiverConfiguration(randomString(), credentials, randomBoolean(), randomBoolean(), randomInt());
+        return new TransceiverConfiguration(randomString(), credentials, randomBoolean(), randomBoolean(), randomInt(),
+            randomString());
     }
 
     public static ReceiverConfiguration randomReceiverConfiguration() {


### PR DESCRIPTION
The systemType parameter is used to categorize the type of ESME that is binding to the SMSC. Examples include “VMS” (voice mail system) and “OTA” (over-the-air activation system).
Specification of the systemType is optional - some SMSC’s may not require ESME’s to provide this detail. In this case, the ESME can set the systemType to NULL.