### PR TITLE
Add auto closing opened connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,6 @@ artifacts {
     archives javadocJar
 }
 
-signing {
-    sign configurations.archives
-}
 
 jacoco{
     toolVersion = "0.8.3"

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ artifacts {
     archives javadocJar
 }
 
+signing {
+    sign configurations.archives
+}
 
 jacoco{
     toolVersion = "0.8.3"

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 group = "com.github.mikesafonov"
-version "1.2.1"
+version "1.4.0"
 
 jar {
     enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 group = "com.github.mikesafonov"
-version "1.4.0"
+version "1.3.0"
 
 jar {
     enabled = true

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
@@ -1,6 +1,5 @@
 package com.github.mikesafonov.smpp.config;
 
-import com.cloudhopper.smpp.SmppSession;
 import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.reciever.ResponseClient;
 import com.github.mikesafonov.smpp.core.sender.SenderClient;
@@ -13,6 +12,7 @@ import java.util.Optional;
  * This class represent configured smsc connection with {@link SenderClient} and {@link ResponseClient} (optionally)
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @Value
 @AllArgsConstructor
@@ -31,7 +31,7 @@ public class SmscConnection {
         return Optional.ofNullable(responseClient);
     }
 
-    public void closeSession(){
+    public void closeConnection(){
         senderClient.getConnectionManager().ifPresent(ConnectionManager::destroy);
     }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
@@ -31,7 +31,10 @@ public class SmscConnection {
         return Optional.ofNullable(responseClient);
     }
 
-    public void closeConnection(){
+    public void closeConnection() {
         senderClient.getConnectionManager().ifPresent(ConnectionManager::destroy);
+        if (responseClient != null) {
+            responseClient.destroyClient();
+        }
     }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
@@ -1,5 +1,7 @@
 package com.github.mikesafonov.smpp.config;
 
+import com.cloudhopper.smpp.SmppSession;
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.reciever.ResponseClient;
 import com.github.mikesafonov.smpp.core.sender.SenderClient;
 import lombok.AllArgsConstructor;
@@ -27,5 +29,9 @@ public class SmscConnection {
 
     public Optional<ResponseClient> getResponseClient() {
         return Optional.ofNullable(responseClient);
+    }
+
+    public void closeSession(){
+        senderClient.getConnectionManager().ifPresent(ConnectionManager::destroy);
     }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionFactoryBean.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionFactoryBean.java
@@ -15,8 +15,6 @@ import lombok.Setter;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 import static com.github.mikesafonov.smpp.core.utils.Utils.getOrDefault;
@@ -25,6 +23,7 @@ import static java.util.stream.Collectors.toList;
 
 /**
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @RequiredArgsConstructor
 public class SmscConnectionFactoryBean implements FactoryBean<SmscConnectionsHolder> {

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionFactoryBean.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionFactoryBean.java
@@ -15,6 +15,8 @@ import lombok.Setter;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 import static com.github.mikesafonov.smpp.core.utils.Utils.getOrDefault;
@@ -82,19 +84,17 @@ public class SmscConnectionFactoryBean implements FactoryBean<SmscConnectionsHol
         if (type == ConnectionType.TRANSCEIVER) {
             ConnectionManager transceiver = connectionManagerFactory.transceiver(name, defaults,
                 smsc, getOrCreateHandler(name, deliveryReportConsumers));
-            SenderClient standardSender = clientFactory.standardSender(name, defaults, smsc,
-                typeOfAddressParser, transceiver);
-            testSenderClient = clientFactory.testSender(standardSender, defaults,
-                smsc, smppResultGenerator);
+            testSenderClient = clientFactory.testSender(name, defaults, smsc,typeOfAddressParser, transceiver,
+                smppResultGenerator);
+
             if (isResponseClientRequired()) {
                 responseClient = clientFactory.standardResponse(name, transceiver);
             }
         } else {
             ConnectionManager transmitter = connectionManagerFactory.transmitter(name, defaults, smsc);
-            SenderClient standardSender = clientFactory.standardSender(name, defaults, smsc,
-                typeOfAddressParser, transmitter);
-            testSenderClient = clientFactory.testSender(standardSender, defaults,
-                smsc, smppResultGenerator);
+            testSenderClient = clientFactory.testSender(name, defaults, smsc,typeOfAddressParser, transmitter,
+                smppResultGenerator);
+
             if (isResponseClientRequired()) {
                 ConnectionManager receiver = connectionManagerFactory.receiver(name, defaults,
                     smsc, getOrCreateHandler(name, deliveryReportConsumers));

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionsHolder.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionsHolder.java
@@ -2,9 +2,15 @@ package com.github.mikesafonov.smpp.config;
 
 import lombok.Value;
 
+import javax.annotation.PreDestroy;
 import java.util.List;
 
 @Value
 public class SmscConnectionsHolder {
     private final List<SmscConnection> connections;
+
+    @PreDestroy
+    public void closeSessions() {
+        connections.forEach(SmscConnection::closeSession);
+    }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionsHolder.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionsHolder.java
@@ -10,7 +10,7 @@ public class SmscConnectionsHolder {
     private final List<SmscConnection> connections;
 
     @PreDestroy
-    public void closeSessions() {
-        connections.forEach(SmscConnection::closeSession);
+    public void closeConnections() {
+        connections.forEach(SmscConnection::closeConnection);
     }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/ClientFactory.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/ClientFactory.java
@@ -20,6 +20,9 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Helper class for building {@link SenderClient} and {@link ResponseClient}
+ *
+ * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 public class ClientFactory {
 

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/MockSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/MockSenderClient.java
@@ -1,5 +1,7 @@
 package com.github.mikesafonov.smpp.core.sender;
 
+import com.cloudhopper.smpp.SmppSession;
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
 import com.github.mikesafonov.smpp.core.dto.Message;
@@ -8,6 +10,8 @@ import com.github.mikesafonov.smpp.core.generators.SmppResultGenerator;
 import lombok.EqualsAndHashCode;
 
 import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,4 +52,8 @@ public class MockSenderClient implements SenderClient {
         return smppResultGenerator.generate(id, cancelMessage);
     }
 
+    @Override
+    public Optional<ConnectionManager> getConnectionManager() {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/MockSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/MockSenderClient.java
@@ -1,6 +1,5 @@
 package com.github.mikesafonov.smpp.core.sender;
 
-import com.cloudhopper.smpp.SmppSession;
 import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
@@ -10,7 +9,6 @@ import com.github.mikesafonov.smpp.core.generators.SmppResultGenerator;
 import lombok.EqualsAndHashCode;
 
 import javax.validation.constraints.NotNull;
-
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -20,6 +18,7 @@ import static java.util.Objects.requireNonNull;
  * {@link MessageResponse}/{@link CancelMessageResponse} by using {@link SmppResultGenerator}
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @EqualsAndHashCode
 public class MockSenderClient implements SenderClient {

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/SenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/SenderClient.java
@@ -1,5 +1,7 @@
 package com.github.mikesafonov.smpp.core.sender;
 
+import com.cloudhopper.smpp.SmppSession;
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
 import com.github.mikesafonov.smpp.core.dto.Message;
@@ -7,6 +9,7 @@ import com.github.mikesafonov.smpp.core.dto.MessageResponse;
 import com.github.mikesafonov.smpp.core.exceptions.SenderClientBindException;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 /**
  * This interface represents smpp protocol transmitter client
@@ -42,4 +45,12 @@ public interface SenderClient {
      * @return cancel response
      */
     @NotNull CancelMessageResponse cancel(@NotNull CancelMessage cancelMessage);
+
+    /**
+     * Get Connection Manager
+     *
+     * @return {@link ConnectionManager}
+     */
+
+    @NotNull Optional<ConnectionManager> getConnectionManager();
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/SenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/SenderClient.java
@@ -1,6 +1,5 @@
 package com.github.mikesafonov.smpp.core.sender;
 
-import com.cloudhopper.smpp.SmppSession;
 import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
@@ -15,6 +14,7 @@ import java.util.Optional;
  * This interface represents smpp protocol transmitter client
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 public interface SenderClient {
 

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/StandardSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/StandardSenderClient.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -58,7 +60,7 @@ public class StandardSenderClient implements SenderClient {
     }
 
     /**
-     * Setup connection to SMSC.
+     * Setup connection to SMSC
      *
      * @throws SenderClientBindException if connection fails
      * @see ConnectionManager#getSession()
@@ -139,6 +141,11 @@ public class StandardSenderClient implements SenderClient {
             return CancelMessageResponse.error(cancelMessage, getId(),
                     new MessageErrorInformation(INVALID_SENDING_ERROR, "Unexpected exception"));
         }
+    }
+
+    @Override
+    public Optional<ConnectionManager> getConnectionManager() {
+        return Optional.of(connectionManager);
     }
 
     @NotNull

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/StandardSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/StandardSenderClient.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
  * {@link SmppSession}
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @Slf4j
 public class StandardSenderClient implements SenderClient {

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/TestSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/TestSenderClient.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
  * Default implementation of {@link SenderClient}, build on top of {@link DefaultSmppClient} and
  * {@link SmppSession}
  *
+ * @author Mike Safonov
  * @author Mikhail Epatko
  */
 @Slf4j

--- a/src/test/java/com/github/mikesafonov/smpp/config/SmscConnectionFactoryBeanTest.java
+++ b/src/test/java/com/github/mikesafonov/smpp/config/SmscConnectionFactoryBeanTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.*;
 
 /**
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 class SmscConnectionFactoryBeanTest {
 


### PR DESCRIPTION
feat: Add auto closing opened connections

Made Spring can close opened connections throw predestroy method of SmscConnectionsHolder.
Made TestSenderClient inherits StandardSenderClient to have ability to implement method #getConnectionManager in the TestSenderClient.
Fixed unit tests.