### PR TITLE
feat: Added Spring auto closing opened connections

### DIFF
--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnection.java
@@ -1,5 +1,6 @@
 package com.github.mikesafonov.smpp.config;
 
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.reciever.ResponseClient;
 import com.github.mikesafonov.smpp.core.sender.SenderClient;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import java.util.Optional;
  * This class represent configured smsc connection with {@link SenderClient} and {@link ResponseClient} (optionally)
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @Value
 @AllArgsConstructor
@@ -27,5 +29,12 @@ public class SmscConnection {
 
     public Optional<ResponseClient> getResponseClient() {
         return Optional.ofNullable(responseClient);
+    }
+
+    public void closeConnection() {
+        senderClient.getConnectionManager().ifPresent(ConnectionManager::destroy);
+        if (responseClient != null) {
+            responseClient.destroyClient();
+        }
     }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionsHolder.java
+++ b/src/main/java/com/github/mikesafonov/smpp/config/SmscConnectionsHolder.java
@@ -2,9 +2,20 @@ package com.github.mikesafonov.smpp.config;
 
 import lombok.Value;
 
+import javax.annotation.PreDestroy;
 import java.util.List;
 
+/**
+ *
+ * @author Mike Safonov
+ * @author Mikhail Epatko
+ */
 @Value
 public class SmscConnectionsHolder {
     private final List<SmscConnection> connections;
+
+    @PreDestroy
+    public void closeConnections() {
+        connections.forEach(SmscConnection::closeConnection);
+    }
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/MockSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/MockSenderClient.java
@@ -1,5 +1,6 @@
 package com.github.mikesafonov.smpp.core.sender;
 
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
 import com.github.mikesafonov.smpp.core.dto.Message;
@@ -9,6 +10,8 @@ import lombok.EqualsAndHashCode;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -16,6 +19,7 @@ import static java.util.Objects.requireNonNull;
  * {@link MessageResponse}/{@link CancelMessageResponse} by using {@link SmppResultGenerator}
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @EqualsAndHashCode
 public class MockSenderClient implements SenderClient {
@@ -46,6 +50,11 @@ public class MockSenderClient implements SenderClient {
     @Override
     public @NotNull CancelMessageResponse cancel(@NotNull CancelMessage cancelMessage) {
         return smppResultGenerator.generate(id, cancelMessage);
+    }
+
+    @Override
+    public Optional<ConnectionManager> getConnectionManager() {
+        return Optional.empty();
     }
 
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/SenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/SenderClient.java
@@ -1,5 +1,6 @@
 package com.github.mikesafonov.smpp.core.sender;
 
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
 import com.github.mikesafonov.smpp.core.dto.Message;
@@ -7,11 +8,13 @@ import com.github.mikesafonov.smpp.core.dto.MessageResponse;
 import com.github.mikesafonov.smpp.core.exceptions.SenderClientBindException;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 /**
  * This interface represents smpp protocol transmitter client
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 public interface SenderClient {
 
@@ -42,4 +45,11 @@ public interface SenderClient {
      * @return cancel response
      */
     @NotNull CancelMessageResponse cancel(@NotNull CancelMessage cancelMessage);
+
+    /**
+     * Get Connection Manager
+     *
+     * @return {@link ConnectionManager}
+     */
+    @NotNull Optional<ConnectionManager> getConnectionManager();
 }

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/StandardSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/StandardSenderClient.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -24,6 +26,7 @@ import static java.util.Objects.requireNonNull;
  * {@link SmppSession}
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 @Slf4j
 public class StandardSenderClient implements SenderClient {
@@ -139,6 +142,11 @@ public class StandardSenderClient implements SenderClient {
             return CancelMessageResponse.error(cancelMessage, getId(),
                     new MessageErrorInformation(INVALID_SENDING_ERROR, "Unexpected exception"));
         }
+    }
+
+    @Override
+    public Optional<ConnectionManager> getConnectionManager() {
+        return Optional.of(connectionManager);
     }
 
     @NotNull

--- a/src/main/java/com/github/mikesafonov/smpp/core/sender/TestSenderClient.java
+++ b/src/main/java/com/github/mikesafonov/smpp/core/sender/TestSenderClient.java
@@ -1,5 +1,6 @@
 package com.github.mikesafonov.smpp.core.sender;
 
+import com.github.mikesafonov.smpp.core.connection.ConnectionManager;
 import com.github.mikesafonov.smpp.core.dto.CancelMessage;
 import com.github.mikesafonov.smpp.core.dto.CancelMessageResponse;
 import com.github.mikesafonov.smpp.core.dto.Message;
@@ -9,6 +10,7 @@ import com.github.mikesafonov.smpp.core.generators.SmppResultGenerator;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -20,6 +22,7 @@ import static java.util.Objects.requireNonNull;
  * will be generated via {@link SmppResultGenerator}
  *
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 public class TestSenderClient implements SenderClient {
 
@@ -67,6 +70,11 @@ public class TestSenderClient implements SenderClient {
             return senderClient.cancel(cancelMessage);
         }
         return smppResultGenerator.generate(senderClient.getId(), cancelMessage);
+    }
+
+    @Override
+    public Optional<ConnectionManager> getConnectionManager() {
+        return senderClient.getConnectionManager();
     }
 
     private boolean isAllowed(String phone) {

--- a/src/test/java/com/github/mikesafonov/smpp/core/ClientFactoryTest.java
+++ b/src/test/java/com/github/mikesafonov/smpp/core/ClientFactoryTest.java
@@ -7,12 +7,12 @@ import com.github.mikesafonov.smpp.core.generators.SmppResultGenerator;
 import com.github.mikesafonov.smpp.core.reciever.ResponseClient;
 import com.github.mikesafonov.smpp.core.reciever.StandardResponseClient;
 import com.github.mikesafonov.smpp.core.sender.*;
-import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import static com.github.mikesafonov.smpp.util.Randomizer.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Mike Safonov
+ * @author Mikhail Epatko
  */
 class ClientFactoryTest {
 
@@ -202,7 +203,7 @@ class ClientFactoryTest {
                 .standardSender(name, defaults, smsc, mock(TypeOfAddressParser.class), connectionManager);
 
             assertThat(client).extracting("ucs2Only", "timeoutMillis", "connectionManager")
-                .containsExactly(ucs2Only, defaults.getRequestTimeout().toMillis(), connectionManager);
+                .containsExactly(ucs2Only, defaults.getRequestTimeout().toMillis(), Optional.of(connectionManager));
         }
     }
 


### PR DESCRIPTION
feat: Added Spring auto closing opened connections

Made Spring can close opened connections throw predestroy method of SmscConnectionsHolder.
Made TestSenderClient inherits StandardSenderClient to have ability to implement method #getConnectionManager in the TestSenderClient.
Fixed unit tests.